### PR TITLE
Add squarewave output format

### DIFF
--- a/examples/audio/hdl/squarewave.v
+++ b/examples/audio/hdl/squarewave.v
@@ -1,0 +1,33 @@
+// generates triangle wave
+
+module squarewave
+#(
+  parameter C_delay = 10, // bits for delay part of the counter
+  parameter C_pcm_bits = 12 // how many bits for PCM output
+)
+(
+  input clk, // required to run PWM
+  output signed [C_pcm_bits-1:0] pcm // 12-bit unsigned PCM output
+);
+
+    reg [C_delay+C_pcm_bits-1:0] R_counter; // PWM counter register
+    reg R_direction;
+
+    always @(posedge clk)
+    begin
+      if(R_direction == 1'b1)
+        R_counter <= R_counter + 1;
+      else
+        R_counter <= R_counter - 1;
+    end
+
+    always @(posedge clk)
+    begin
+      if( R_counter[C_delay+C_pcm_bits-1:C_delay] == ~{12'd1770} && R_direction == 1'b0)
+        R_direction <= 1'b1; // from now on, count forwards
+      if( R_counter[C_delay+C_pcm_bits-1:C_delay] == 12'd1770 && R_direction == 1'b1)
+        R_direction <= 1'b0; // from now on, count backwards
+    end
+
+  assign pcm = {R_direction, 11'b000_0000_0000};
+endmodule

--- a/examples/audio/makefile.trellis
+++ b/examples/audio/makefile.trellis
@@ -24,6 +24,7 @@ TOP_MODULE_FILE = hdl/$(TOP_MODULE).v
 VERILOG_FILES = \
   $(TOP_MODULE_FILE) \
   hdl/trianglewave.v \
+  hdl/squarewave.v \
   hdl/sinewave.v \
   hdl/dacpwm.v \
   hdl/i2s_v.v


### PR DESCRIPTION
Add squarewave output option, has same interface as
the triangle and sine wave outputs.